### PR TITLE
Remove rapidfuzz dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 python-telegram-bot==20.8
 pymongo==4.7.3
-rapidfuzz==3.13.0
 requests
 fuzzywuzzy


### PR DESCRIPTION
The `rapidfuzz` library is an optional dependency for `fuzzywuzzy` that provides performance improvements for fuzzy string matching. It is not directly used in the codebase.

This change removes `rapidfuzz` from the `requirements.txt` file. `fuzzywuzzy` will automatically fall back to its pure Python implementation, so no code changes are necessary.