### PR TITLE
Add Flask web server to keep bot alive on Render

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-telegram-bot==21.0.1
 pymongo==4.7.3
 requests
 fuzzywuzzy
+Flask


### PR DESCRIPTION
This commit introduces a minimal Flask web server that runs in a background thread. This is a workaround to solve a deployment issue on the Render platform.

The bot is deployed as a "Web Service," which requires an application to bind to a port to respond to health checks. Since the bot itself doesn't open a port, Render was timing out and shutting it down.

This change adds a simple Flask app that:
- Runs concurrently with the bot in a separate thread.
- Listens on the port specified by the `PORT` environment variable.
- Responds to HTTP requests, satisfying Render's health checks and preventing the service from being terminated.

This also includes previous dependency fixes:
- `rapidfuzz` was removed.
- `python-telegram-bot` was upgraded to `21.0.1` to fix a startup crash.