### PR TITLE
feat: Implement referral system and tune search logic

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1845,8 +1845,12 @@ async def search_files(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if file_key in unique_files:
             continue
 
-        # Use WRatio for a more robust score that handles partial strings and other variations well.
-        score = fuzz.WRatio(normalized_query, file['file_name'])
+        # Check for an exact match first to prioritize it
+        if normalized_query.lower() == file['file_name'].lower():
+            score = 101 # Give a score higher than any possible fuzzy score
+        else:
+            # Use WRatio for a more robust score that handles partial strings and other variations well.
+            score = fuzz.WRatio(normalized_query, file['file_name'])
 
         # Keep results that have a score above 60 for better relevance.
         if score > 60:


### PR DESCRIPTION
This commit introduces a "refer and earn" system, fixes a referral counting bug, and improves the search functionality.

Key changes include:
- A new `/refer` command to generate unique referral links.
- Modified `/start` command to track referrals and grant premium status.
- A new `referred_users` collection to correctly track new referrals and prevent duplicate counting.
- Updated user verification to recognize premium users, allowing them to bypass the standard verification process.
- A new MongoDB collection to store referral data, with a TTL index to automatically expire premium status after 30 days.
- The fuzzy search similarity threshold has been increased to 60 for stricter results.
- Exact search matches are now prioritized and will always appear at the top of the results.
- As per explicit user instruction, all configuration values, including the bot token and database URIs, have been hardcoded directly into the `bot.py` file.
- The `README.md` has been updated to remove environment variable instructions.