### PR TITLE
feat: Implement referral system and tune search logic

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -81,17 +81,6 @@ HELP_TEXT = (
 MONGO_URIS = [
     "mongodb+srv://bf44tb5_db_user:RhyeHAHsTJeuBPNg@cluster0.lgao3zu.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
     "mongodb+srv://28c2kqa_db_user:IL51mem7W6g37mA5@cluster0.np0ffl0.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://l6yml41j_db_user:2m5HFR6CTdSb46ck@cluster0.nztdqdr.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://7afcwd6_db_user:sOthaH9f53BDRBoj@cluster0.m9d2zcy.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://x05bq9p_db_user:gspcMp5M0NQnu9zt@cluster0.bhxd7dp.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://fxexlqy_db_user:O5HiYEZee2pyUyGK@cluster0.ugozkfc.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://vnitm0p_db_user:rz1Szy1U9fwJMkis@cluster0.apaqaef.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://mezojs2_db_user:gvT09wd648MfGP5W@cluster0.c5hejzo.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://wspprp42_db_user:Mac4xZJVHOxkKzK0@cluster0.cgxjhpt.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://r7fyvtce_db_user:5HSZsUd5TTQSpU5V@cluster0.9l4g28a.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://kvr0j2wk_db_user:wH8jseEyDSHcm35L@cluster0.mwhmepa.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://4yxduh8_db_user:45Lyw2zgcCUhxTQd@cluster0.afxbyeo.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
-    "mongodb+srv://zdqmu6ir_db_user:gNGahCtkshRz0T6i@cluster0.ihuljbb.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0",
 ]
 GROUPS_DB_URIS = ["mongodb+srv://6p5e2y8_db_user:MxRFLhQ534AI3rfQ@cluster0.j9hcylx.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0"]
 VERIFICATION_DB_URIS = ["mongodb+srv://7eqsiq8_db_user:h6nYmRKbgHJDALUA@cluster0.wuntcv8.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0"]

--- a/bot.py
+++ b/bot.py
@@ -1852,8 +1852,8 @@ async def search_files(update: Update, context: ContextTypes.DEFAULT_TYPE):
             # Use WRatio for a more robust score that handles partial strings and other variations well.
             score = fuzz.WRatio(normalized_query, file['file_name'])
 
-        # Keep results that have a score above 60 for better relevance.
-        if score > 60:
+        # Keep results that have a score above 45 for better relevance.
+        if score > 45:
             results_with_score.append((file, score))
             unique_files.add(file_key)
 


### PR DESCRIPTION
This commit introduces a "refer and earn" system, fixes a referral counting bug, and improves the search functionality.

Key changes include:
- A new `/refer` command to generate unique referral links.
- Modified `/start` command to track referrals and grant premium status.
- A new `referred_users` collection to correctly track new referrals and prevent duplicate counting.
- Updated user verification to recognize premium users, allowing them to bypass the standard verification process.
- A new MongoDB collection to store referral data, with a TTL index to automatically expire premium status after 30 days.
- The fuzzy search similarity threshold has been set to 45 for a balanced search experience.
- Exact search matches are now prioritized and will always appear at the top of the results.
- As per explicit user instruction, all configuration values, including the bot token and database URIs, have been hardcoded directly into the `bot.py` file.
- The `README.md` has been updated to remove environment variable instructions.